### PR TITLE
Fix race condition when call same function concurently

### DIFF
--- a/database.go
+++ b/database.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+
+	"strconv"
 
 	log "github.com/Sirupsen/logrus"
 	_ "github.com/bmizerany/pq"
 	"github.com/jinzhu/gorm"
-	"strconv"
 )
 
 // dbWrite dbRead dbLogger: variable for database
@@ -17,6 +19,7 @@ var (
 	dbWrite, dbRead *gorm.DB
 	dbLogger        *log.Logger
 	isDebug         bool
+	dbReadMu        sync.Mutex
 )
 
 // DBLogFormatter database log formatter
@@ -85,6 +88,9 @@ func GetWriteDB() *gorm.DB {
 
 // GetReadDB function to get reading access to database
 func GetReadDB() *gorm.DB {
+	dbReadMu.Lock()
+	defer dbReadMu.Unlock()
+
 	if dbRead == nil {
 		//dbRead = CreateDBConnection(os.Getenv("DB_READ"))
 		dbRead = CreateDBConnection(fmt.Sprintf("host=%s user=%s "+


### PR DESCRIPTION
Di pyro ada beberapa fungsi untuk get data dari database menggunakan goroutine
alhasil waktu cek race condition muncul warning seperti ini

```
==================
WARNING: DATA RACE
Write at 0x000001e30850 by goroutine 25:
  github.com/Bhinneka/pyrosoma-backend/vendor/github.com/Bhinneka/golib.GetReadDB()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/vendor/github.com/Bhinneka/golib/database.go:90 +0x347
  github.com/Bhinneka/pyrosoma-backend/service.(*DBHandler).GetVendorContactsByVendorID()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/service/vendorContactService.go:24 +0x61
  github.com/Bhinneka/pyrosoma-backend/repository.GetVendorContactConcurrently()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/repository/vendorContactRepository.go:23 +0x69

Previous read at 0x000001e30850 by goroutine 31:
  github.com/Bhinneka/pyrosoma-backend/vendor/github.com/Bhinneka/golib.GetReadDB()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/vendor/github.com/Bhinneka/golib/database.go:88 +0x4f
  github.com/Bhinneka/pyrosoma-backend/service.(*DBHandler).GetVendorBanksByVendorID()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/service/vendorBankService.go:23 +0x61
  github.com/Bhinneka/pyrosoma-backend/repository.GetVATBankConcurrently()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/repository/vendorBankRepository.go:23 +0x5f

Goroutine 25 (running) created at:
  github.com/Bhinneka/pyrosoma-backend/repository.CollectMyVendorDetailResponse()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/repository/vendorRepository.go:730 +0x123a
  github.com/Bhinneka/pyrosoma-backend/pkg/vendors.(*Service).GetMyVendorDetail()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/pkg/vendors/service.go:103 +0xdf
  github.com/Bhinneka/pyrosoma-backend/pkg/vendors.TestGetMyVendorDetail()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/pkg/vendors/service_test.go:31 +0xdd
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d

Goroutine 31 (running) created at:
  github.com/Bhinneka/pyrosoma-backend/repository.CollectMyVendorDetailResponse()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/repository/vendorRepository.go:733 +0x1279
  github.com/Bhinneka/pyrosoma-backend/pkg/vendors.(*Service).GetMyVendorDetail()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/pkg/vendors/service.go:103 +0xdf
  github.com/Bhinneka/pyrosoma-backend/pkg/vendors.TestGetMyVendorDetail()
      /Users/edifirmansyah/Workspace/go/src/github.com/Bhinneka/pyrosoma-backend/pkg/vendors/service_test.go:31 +0xdd
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
==================
```

Solusi dari golang adalah menggunakan mutex untuk shared variable
https://golang.org/doc/articles/race_detector.html\#Unprotected_global_variable