### PR TITLE
code-cov : fix code coverage slack getCaller()

### DIFF
--- a/slack_test.go
+++ b/slack_test.go
@@ -3,6 +3,7 @@ package golib
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,8 @@ import (
 
 func Test_getCaller(t *testing.T) {
 	t.Run("TEST getCaller", func(t *testing.T) {
-		assert.Equal(t, "runtime.goexit:1358", getCaller())
+		b := strings.Contains(getCaller(), "runtime")
+		assert.Equal(t, true, b)
 	})
 }
 


### PR DESCRIPTION
fix slack getCaller() code coverage due to different goexit runtime code